### PR TITLE
Using expo Constants for managing app version directly

### DIFF
--- a/src/screens/ConfigurationScreen/index.js
+++ b/src/screens/ConfigurationScreen/index.js
@@ -11,6 +11,7 @@ import {
   Switch,
   TouchableOpacity
 } from 'react-native';
+import { Constants } from 'expo';
 
 import { Feather } from '@expo/vector-icons';
 
@@ -139,7 +140,7 @@ export default class ConfigurationScreen extends Component {
             </TouchableOpacity>
             <View style={[styles.item, styles.itemNoBorder]}>
               <Text style={styles.itemTextVersion} numberOfLines={2}>
-                Version 1.0.0
+                Version {Constants.manifest.version}
               </Text>
             </View>
           </View>


### PR DESCRIPTION
So you don't have to update it manually after changing it on the `app.json` file.